### PR TITLE
fix: `Null Pointer Exception` on `dependentFields` method.

### DIFF
--- a/src/main/java/org/spin/eca56/util/support/documents/DependenceUtil.java
+++ b/src/main/java/org/spin/eca56/util/support/documents/DependenceUtil.java
@@ -91,11 +91,17 @@ public class DependenceUtil {
 	
 	public static List<Map<String, Object>> generateDependentProcessParameters(MProcessPara processParameter) {
 		List<Map<String, Object>> depenentFieldsList = new ArrayList<>();
+		if (processParameter == null) {
+			return depenentFieldsList;
+		}
 
 		String parentColumnName = processParameter.getColumnName();
 
 		MProcess process = MProcess.get(processParameter.getCtx(), processParameter.getAD_Process_ID());
 		List<MProcessPara> parametersList = process.getParametersAsList();
+		if (parametersList == null || parametersList.isEmpty()) {
+			return depenentFieldsList;
+		}
 
 		parametersList.parallelStream()
 			.filter(currentParameter -> {
@@ -140,10 +146,13 @@ public class DependenceUtil {
 	
 	public static List<Map<String, Object>> generateDependentWindowFields(MField field) {
 		List<Map<String, Object>> depenentFieldsList = new ArrayList<>();
+		if (field == null) {
+			return depenentFieldsList;
+		}
 		String parentColumnName = MColumn.getColumnName(field.getCtx(), field.getAD_Column_ID());
 		MTab parentTab = MTab.get(field.getCtx(), field.getAD_Tab_ID());
 		List<MTab> tabsList = Arrays.asList(MWindow.get(field.getCtx(), parentTab.getAD_Window_ID()).getTabs(false, null));
-		if (tabsList == null) {
+		if (tabsList == null || tabsList.isEmpty()) {
 			return depenentFieldsList;
 		}
 		tabsList.parallelStream()
@@ -153,7 +162,7 @@ public class DependenceUtil {
 			})
 			.forEach(tab -> {
 				List<MField> fieldsList = Arrays.asList(tab.getFields(false, null));
-				if (fieldsList == null) {
+				if (fieldsList == null || fieldsList.isEmpty()) {
 					return;
 				}
 
@@ -218,6 +227,9 @@ public class DependenceUtil {
 	
 	public static List<Map<String, Object>> generateDependentBrowseFields(MBrowseField browseField) {
 		List<Map<String, Object>> depenentFieldsList = new ArrayList<>();
+		if (browseField == null) {
+			return depenentFieldsList;
+		}
 
 		MViewColumn viewColumn = MViewColumn.getById(Env.getCtx(), browseField.getAD_View_Column_ID(), null);
 		String parentColumnName = viewColumn.getColumnName();
@@ -234,6 +246,9 @@ public class DependenceUtil {
 
 		MBrowse browse = MBrowse.get(browseField.getCtx(), browseField.getAD_Browse_ID());
 		List<MBrowseField> browseFieldsList = browse.getFields();
+		if (browseFieldsList == null || browseFieldsList.isEmpty()) {
+			return depenentFieldsList;
+		}
 
 		browseFieldsList.parallelStream()
 			.filter(currentBrowseField -> {


### PR DESCRIPTION
```log
===========> Dictionary.getBrowser: null [6250]                                                                      
java.lang.NullPointerException                                                                                       
        at org.spin.grpc.service.dictionary.BrowseConverUtil.generateDependentBrowseFields(BrowseConverUtil.java:320) 
        at org.spin.grpc.service.dictionary.BrowseConverUtil.convertBrowseField(BrowseConverUtil.java:293)                                                                                                                                 
        at org.spin.grpc.service.dictionary.BrowseConverUtil.convertBrowser(BrowseConverUtil.java:136)
        at org.spin.grpc.service.dictionary.Dictionary.getBrowser(Dictionary.java:270)
        at org.spin.grpc.service.dictionary.Dictionary.getBrowser(Dictionary.java:240)
        at org.spin.backend.grpc.dictionary.DictionaryGrpc$MethodHandlers.invoke(DictionaryGrpc.java:900)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:351)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829) 
````