### PR TITLE
feat: Add filter record `ColumnName` to Sort Tab.

### DIFF
--- a/src/main/java/org/spin/eca56/util/support/documents/Window.java
+++ b/src/main/java/org/spin/eca56/util/support/documents/Window.java
@@ -221,6 +221,31 @@ public class Window extends DictionaryDocument {
 				MColumn column = MColumn.get(tab.getCtx(), tab.getAD_ColumnSortYesNo_ID());
 				detail.put("sort_yes_no_column_name", column.getColumnName());
 			}
+
+			//	Parent Column from parent tab
+			MTab parentTab = new Query(
+				tab.getCtx(),
+				I_AD_Tab.Table_Name,
+				"AD_Window_ID = ? AND AD_Table_ID = ? AND IsSortTab = ?",
+				null
+			)
+				.setParameters(tab.getAD_Window_ID(), table.getAD_Table_ID(), false)
+				.first()
+			;
+			if (parentTab != null && parentTab.getAD_Tab_ID() > 0) {
+				// is same table and columns
+				List<MColumn> columnsList = table.getColumnsAsList();
+				MColumn parentColumn = columnsList.parallelStream()
+					.filter(column -> {
+						return column.isParent();
+					})
+					.findFirst()
+					.orElse(null)
+				;
+				if (parentColumn != null && parentColumn.getAD_Column_ID() > 0) {
+					detail.put("filter_column_name", parentColumn.getColumnName());
+				}
+			}
 		}
 
 		// External info


### PR DESCRIPTION
The filter column for the order tabs must be added, currently it is done from the front end, locating the parent tab and taking the column marked as parent to send it and filter the records. It is preferable to add it in the backend as this is not usually changed, improving performance on the frontend side.

related issue https://github.com/solop-develop/frontend-core/issues/2070