### PR TITLE
fix: Context columns by where clause with tab level.

### DIFF
--- a/src/main/java/org/spin/eca56/util/support/documents/ReferenceUtil.java
+++ b/src/main/java/org/spin/eca56/util/support/documents/ReferenceUtil.java
@@ -78,17 +78,21 @@ public class ReferenceUtil {
 		String END   = "\\@";  // A literal ")" character in regex
 
 		// Captures the word(s) between the above two character(s)
-		String patternValue = START + "(#|$){0,1}(\\w+)" + END;
+		final String COLUMN_NAME_PATTERN = START + "(#|$|\\d\\|){0,1}(\\w+)" + END;
 
-		Pattern pattern = Pattern.compile(patternValue);
+		Pattern pattern = Pattern.compile(
+			COLUMN_NAME_PATTERN,
+			Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+		);
 		Matcher matcher = pattern.matcher(context);
 		Map<String, Boolean> columnNamesMap = new HashMap<String, Boolean>();
 		while(matcher.find()) {
-			columnNamesMap.put(matcher.group().replace("@", "").replace("@", ""), true);
+			final String columnContext = matcher.group().replace("@", "").replace("@", "");
+			columnNamesMap.put(columnContext, true);
 		}
 		return new ArrayList<String>(columnNamesMap.keySet());
 	}
-	
+
 	public static ReferenceValues getReferenceDefinition(String columnName, int referenceId, int referenceValueId, int validationRuleId) {
 		String embeddedContextColumn = null;
 		if(referenceId > 0 && ReferenceUtil.isLookupReference(referenceId)) {


### PR DESCRIPTION
When `Where Clause` on tab includes tab level on column name as context for example `@0|Column@`


![imagen](https://github.com/user-attachments/assets/02d3f9fe-d8d9-4092-89d4-4f277b26c022)

```
AD_NotificationQueue.AD_NotificationQueue_ID=@0|AD_NotificationQueue_ID@
```
