### PR TITLE
fix: Infinity loop when `Node_ID` equal `0`.

### DIFF
--- a/src/main/java/org/spin/eca56/util/queue/ApplicationDictionary.java
+++ b/src/main/java/org/spin/eca56/util/queue/ApplicationDictionary.java
@@ -64,6 +64,7 @@ public class ApplicationDictionary extends QueueManager implements IEngineDictio
 			queue.setProcessed(true);
 			queue.saveEx();
 		} catch (Throwable e) {
+			// e.printStackTrace();
 			logger.warning(e.getLocalizedMessage());
 		}
 	}
@@ -92,6 +93,7 @@ public class ApplicationDictionary extends QueueManager implements IEngineDictio
 				if(documentByLanguage != null) {
 					sender.send(documentByLanguage, documentByLanguage.getChannel());
 				}
+				// TODO: Skip with AD_Tree and AD_Role
 				getLanguages().forEach(languageId -> {
 					MLanguage language = new MLanguage(getContext(), languageId, getTransactionName());
 					IGenericDictionaryDocument aloneDocument = getDocumentManager(entity, language.getAD_Language());

--- a/src/main/java/org/spin/eca56/util/queue/ApplicationDictionary.java
+++ b/src/main/java/org/spin/eca56/util/queue/ApplicationDictionary.java
@@ -73,7 +73,7 @@ public class ApplicationDictionary extends QueueManager implements IEngineDictio
 	public void process(int queueId) {
 		send(queueId);
 	}
-	
+
 	private String getDictionaryCode() {
 		// Only system
 		MClientInfo clientInfo = MClientInfo.get(getContext(), 0);
@@ -83,7 +83,7 @@ public class ApplicationDictionary extends QueueManager implements IEngineDictio
 		}
 		return code.toLowerCase();
 	}
-	
+
 	public void send(int queueId) {
 		PO entity = getEntity();
 		if(entity != null) {
@@ -93,7 +93,7 @@ public class ApplicationDictionary extends QueueManager implements IEngineDictio
 				if(documentByLanguage != null) {
 					sender.send(documentByLanguage, documentByLanguage.getChannel());
 				}
-				// TODO: Skip with AD_Tree and AD_Role
+				// TODO: Skip with `AD_Tree` and `AD_Role`
 				getLanguages().forEach(languageId -> {
 					MLanguage language = new MLanguage(getContext(), languageId, getTransactionName());
 					IGenericDictionaryDocument aloneDocument = getDocumentManager(entity, language.getAD_Language());
@@ -107,7 +107,7 @@ public class ApplicationDictionary extends QueueManager implements IEngineDictio
 			logger.fine("Queue Processed: " + queueId);
 		}
 	}
-	
+
 	private List<Integer> getLanguages() {
 		return new Query(getContext(), I_AD_Language.Table_Name, "(IsBaseLanguage = 'Y' OR IsSystemLanguage = 'Y')", getTransactionName())
 				.setOnlyActiveRecords(true)

--- a/src/main/java/org/spin/eca56/util/support/documents/MenuTree.java
+++ b/src/main/java/org/spin/eca56/util/support/documents/MenuTree.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.adempiere.core.domains.models.I_AD_TreeNodeMM;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MTree;
 import org.compiere.model.PO;
@@ -73,11 +74,15 @@ public class MenuTree extends DictionaryDocument {
 			while (resulset.next()) {
 				TreeNodeReference treeNode = TreeNodeReference.newInstance()
 					.withNodeId(
-						resulset.getInt("Node_ID")
+						resulset.getInt(
+							I_AD_TreeNodeMM.COLUMNNAME_Node_ID
+						)
 					)
 					.withParentId(parentId)
 					.withSequence(
-						resulset.getInt("SeqNo")
+						resulset.getInt(
+							I_AD_TreeNodeMM.COLUMNNAME_SeqNo
+						)
 					)
 				;
 				nodesList.add(treeNode);

--- a/src/main/java/org/spin/eca56/util/support/documents/MenuTree.java
+++ b/src/main/java/org/spin/eca56/util/support/documents/MenuTree.java
@@ -60,30 +60,32 @@ public class MenuTree extends DictionaryDocument {
 	private List<TreeNodeReference> getChildren(int treeId, int parentId) {
 		String tableName = MTree.getNodeTableName(MTree.TREETYPE_Menu);
 		final String sql = "SELECT tn.Node_ID, tn.SeqNo "
-				+ "FROM " + tableName + " tn "
-				+ "WHERE tn.AD_Tree_ID = ? "
-				+ "AND COALESCE(tn.Parent_ID, 0) = ?"
+			+ "FROM " + tableName + " tn "
+			+ "WHERE tn.Node_ID > 0 "
+			+ "AND tn.AD_Tree_ID = ? "
+			+ "AND COALESCE(tn.Parent_ID, 0) = ?"
 		;
 		List<Object> parameters = new ArrayList<Object>();
 		parameters.add(treeId);
 		parameters.add(parentId);
-		List<TreeNodeReference> nodeIds = new ArrayList<TreeNodeReference>();
+		List<TreeNodeReference> nodesList = new ArrayList<TreeNodeReference>();
 		DB.runResultSet(null, sql, parameters, resulset -> {
 			while (resulset.next()) {
-				nodeIds.add(TreeNodeReference.newInstance()
+				TreeNodeReference treeNode = TreeNodeReference.newInstance()
 					.withNodeId(
 						resulset.getInt("Node_ID")
 					)
 					.withParentId(parentId)
 					.withSequence(
-						resulset.getInt("SeqNo"))
+						resulset.getInt("SeqNo")
 					)
 				;
+				nodesList.add(treeNode);
 			}
 		}).onFailure(throwable -> {
 			throw new AdempiereException(throwable);
 		});
-		return nodeIds;
+		return nodesList;
 	}
 
 	public MenuTree withNode(MTree tree) {


### PR DESCRIPTION
![imagen](https://github.com/user-attachments/assets/2660ecb7-607c-4959-81a9-20177bbbd0b1)

```sql
SELECT tn.Node_ID, tn.SeqNo FROM AD_TreeNodeMM tn
WHERE tn.AD_Tree_ID = 1000035 AND COALESCE(tn.Parent_ID, 0) = 0
```


```sql
SELECT tn.Node_ID, tn.SeqNo FROM AD_TreeNodeMM tn
WHERE tn.Node_ID > 0 AND tn.AD_Tree_ID = 1000035 AND COALESCE(tn.Parent_ID, 0) = 0
```

#### Additional context
ref https://github.com/solop-develop/adempiere-solop/issues/147