### PR TITLE
fix: Reference with correct context columns

### DIFF
--- a/src/main/java/org/spin/eca56/util/support/documents/AccountingUtils.java
+++ b/src/main/java/org/spin/eca56/util/support/documents/AccountingUtils.java
@@ -1,0 +1,73 @@
+/************************************************************************************
+ * Copyright (C) 2018-present E.R.P. Consultores y Asociados, C.A.                  *
+ * Contributor(s): Edwin Betancourt, EdwinBetanc0urt@outlook.com                    *
+ * This program is free software: you can redistribute it and/or modify             *
+ * it under the terms of the GNU General Public License as published by             *
+ * the Free Software Foundation, either version 2 of the License, or                *
+ * (at your option) any later version.                                              *
+ * This program is distributed in the hope that it will be useful,                  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
+ * GNU General Public License for more details.                                     *
+ * You should have received a copy of the GNU General Public License                *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
+ ************************************************************************************/
+package org.spin.eca56.util.support.documents;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.adempiere.core.domains.models.I_C_AcctSchema_Element;
+import org.adempiere.core.domains.models.I_C_ValidCombination;
+import org.adempiere.core.domains.models.X_C_AcctSchema_Element;
+// import org.compiere.model.MAcctSchema;
+import org.compiere.model.MAcctSchemaElement;
+import org.compiere.model.MColumn;
+import org.compiere.model.Query;
+import org.compiere.util.Env;
+
+public class AccountingUtils {
+
+	public static List<String> USER_LIST_COLUMNS = Arrays.asList(
+		I_C_ValidCombination.COLUMNNAME_User1_ID,
+		I_C_ValidCombination.COLUMNNAME_User2_ID,
+		I_C_ValidCombination.COLUMNNAME_User3_ID,
+		I_C_ValidCombination.COLUMNNAME_User4_ID
+	);
+
+
+	public static List<String> USER_ELEMENT_COLUMNS = Arrays.asList(
+		I_C_ValidCombination.COLUMNNAME_UserElement1_ID,
+		I_C_ValidCombination.COLUMNNAME_UserElement2_ID
+	);
+
+
+	public static String overwriteColumnName(String columnName) {
+		if (!USER_ELEMENT_COLUMNS.contains(columnName)) {
+			return null;
+		}
+		final int clientId = Env.getAD_Client_ID(Env.getCtx());
+		if (clientId <= 0) {
+			return null;
+		}
+		final int accountingSchemaId = Env.getContextAsInt(Env.getCtx(), "$C_AcctSchema_ID");
+		if (accountingSchemaId > 0) {
+			// MAcctSchema accountingSchema = MAcctSchema.get(Env.getCtx(), accountingSchemaId, null);
+			MAcctSchemaElement schemaElement = new Query(
+				Env.getCtx(),
+				I_C_AcctSchema_Element.Table_Name,
+				"C_AcctSchema_ID = ? AND (ElementType = ? OR ElementType = ?)",
+				null
+			)
+				.setParameters(accountingSchemaId, X_C_AcctSchema_Element.ELEMENTTYPE_UserElement1, X_C_AcctSchema_Element.ELEMENTTYPE_UserElement2)
+				.first()
+			;
+			if (schemaElement != null && schemaElement.getAD_Column_ID() > 0) {
+				MColumn column = MColumn.get(Env.getCtx(), schemaElement.getAD_Column_ID());
+				return column.getColumnName();
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/org/spin/eca56/util/support/documents/Browser.java
+++ b/src/main/java/org/spin/eca56/util/support/documents/Browser.java
@@ -34,6 +34,7 @@ import org.adempiere.model.MBrowse;
 import org.adempiere.model.MBrowseField;
 import org.adempiere.model.MViewColumn;
 import org.compiere.model.MColumn;
+import org.compiere.model.MLookupInfo;
 import org.compiere.model.MProcess;
 import org.compiere.model.MTable;
 import org.compiere.model.MWindow;
@@ -231,8 +232,7 @@ public class Browser extends DictionaryDocument {
 		detail.put("is_identifier", field.isIdentifier());
 
 		MViewColumn viewColumn = MViewColumn.getById(field.getCtx(), field.getAD_View_Column_ID(), null);
-		String columnName = viewColumn.getColumnName();
-		detail.put("column_name", columnName);
+		detail.put("column_name", viewColumn.getColumnName());
 
 		//	Value Properties
 		detail.put("is_range", field.isRange());
@@ -270,23 +270,43 @@ public class Browser extends DictionaryDocument {
 			elementName = field.getAD_Element().getColumnName();
 		}
 		detail.put("element_name", elementName);
-		ReferenceValues referenceValues = ReferenceUtil.getReferenceDefinition(
-			elementName,
+
+		//	Reference Value
+		int referenceValueId = field.getAD_Reference_Value_ID();
+
+		// overwrite display type `Button` to `List`, example `PaymentRule` or `Posted`
+		int displayTypeId = ReferenceUtil.overwriteDisplayType(
 			field.getAD_Reference_ID(),
-			field.getAD_Reference_Value_ID(),
-			field.getAD_Val_Rule_ID()
+			referenceValueId
 		);
-		if(referenceValues != null) {
-			Map<String, Object> referenceDetail = new HashMap<>();
-			referenceDetail.put("table_name", referenceValues.getTableName());
-			referenceDetail.put("reference_id", referenceValues.getReferenceId());
-			referenceDetail.put("reference_value_id", field.getAD_Reference_Value_ID());
-			referenceDetail.put("context_column_names", ReferenceUtil.getContextColumnNames(
-					referenceValues.getEmbeddedContextColumn()
-				)
+		if (ReferenceUtil.isLookupReference(displayTypeId)) {
+			//	Validation Code
+			int validationRuleId = field.getAD_Val_Rule_ID();
+
+			// TODO: Verify this conditional with "elementName" variable
+			String columnName = field.getAD_Element().getColumnName();
+			if (viewColumn.getAD_Column_ID() > 0) {
+				MColumn column = MColumn.get(field.getCtx(), viewColumn.getAD_Column_ID());
+				columnName = column.getColumnName();
+			}
+
+			MLookupInfo info = ReferenceUtil.getReferenceLookupInfo(
+				displayTypeId, referenceValueId, columnName, validationRuleId
 			);
-			detail.put("reference", referenceDetail);
+			if (info != null) {
+				ReferenceValues referenceValues = ReferenceValues.newInstance(info);
+				Map<String, Object> referenceDetail = new HashMap<>();
+				referenceDetail.put("table_name", referenceValues.getTableName());
+				referenceDetail.put("access_level", referenceValues.getAccessLevel());
+				referenceDetail.put("reference_id", referenceValues.getDisplayTypeId());
+				referenceDetail.put("reference_value_id", referenceValues.getReferenceValueId());
+				referenceDetail.put("context_column_names", referenceValues.getContextColumns());
+				detail.put("reference", referenceDetail);
+			} else {
+				// detail.put("display_type", DisplayType.String);
+			}
 		}
+
 		detail.put("context_column_names", ReferenceUtil.getContextColumnNames(
 				Optional.ofNullable(field.getDefaultValue()).orElse("")
 				+ Optional.ofNullable(field.getDefaultValue2()).orElse("")

--- a/src/main/java/org/spin/eca56/util/support/documents/Process.java
+++ b/src/main/java/org/spin/eca56/util/support/documents/Process.java
@@ -29,6 +29,7 @@ import org.adempiere.core.domains.models.I_AD_Process;
 import org.adempiere.core.domains.models.I_AD_Process_Para;
 import org.adempiere.model.MBrowse;
 import org.compiere.model.MForm;
+import org.compiere.model.MLookupInfo;
 import org.compiere.model.MProcess;
 import org.compiere.model.MProcessPara;
 import org.compiere.model.MReportView;
@@ -194,18 +195,34 @@ public class Process extends DictionaryDocument {
 		detail.put("is_info_only", parameter.isInfoOnly());
 
 		// External Info
-		ReferenceValues referenceValues = ReferenceUtil.getReferenceDefinition(parameter.getColumnName(), parameter.getAD_Reference_ID(), parameter.getAD_Reference_Value_ID(), parameter.getAD_Val_Rule_ID());
-		if(referenceValues != null) {
-			Map<String, Object> referenceDetail = new HashMap<>();
-			referenceDetail.put("table_name", referenceValues.getTableName());
-			referenceDetail.put("reference_id", referenceValues.getReferenceId());
-			referenceDetail.put("reference_value_id", parameter.getAD_Reference_Value_ID());
-			referenceDetail.put("context_column_names", ReferenceUtil.getContextColumnNames(
-					referenceValues.getEmbeddedContextColumn()
-				)
+		int referenceValueId = parameter.getAD_Reference_Value_ID();
+
+		// overwrite display type `Button` to `List`, example `PaymentRule` or `Posted`
+		int displayTypeId = ReferenceUtil.overwriteDisplayType(
+			parameter.getAD_Reference_ID(),
+			referenceValueId
+		);
+		if (ReferenceUtil.isLookupReference(displayTypeId)) {
+			//	Validation Code
+			int validationRuleId = parameter.getAD_Val_Rule_ID();
+
+			MLookupInfo info = ReferenceUtil.getReferenceLookupInfo(
+				displayTypeId, referenceValueId, parameter.getColumnName(), validationRuleId
 			);
-			detail.put("reference", referenceDetail);
+			if (info != null) {
+				ReferenceValues referenceValues = ReferenceValues.newInstance(info);
+				Map<String, Object> referenceDetail = new HashMap<>();
+				referenceDetail.put("table_name", referenceValues.getTableName());
+				referenceDetail.put("access_level", referenceValues.getAccessLevel());
+				referenceDetail.put("reference_id", referenceValues.getDisplayTypeId());
+				referenceDetail.put("reference_value_id", referenceValues.getReferenceValueId());
+				referenceDetail.put("context_column_names", referenceValues.getContextColumns());
+				detail.put("reference", referenceDetail);
+			} else {
+				// detail.put("display_type", DisplayType.String);
+			}
 		}
+
 		detail.put("context_column_names", ReferenceUtil.getContextColumnNames(
 				Optional.ofNullable(parameter.getDefaultValue()).orElse("")
 				+ Optional.ofNullable(parameter.getDefaultValue2()).orElse("")

--- a/src/main/java/org/spin/eca56/util/support/documents/ReferenceUtil.java
+++ b/src/main/java/org/spin/eca56/util/support/documents/ReferenceUtil.java
@@ -22,22 +22,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.adempiere.core.domains.models.I_AD_Chart;
 import org.adempiere.core.domains.models.I_AD_Image;
 import org.adempiere.core.domains.models.I_AD_Ref_List;
 import org.adempiere.core.domains.models.I_C_ElementValue;
 import org.adempiere.core.domains.models.I_C_Location;
+import org.adempiere.core.domains.models.I_C_ValidCombination;
 import org.adempiere.core.domains.models.I_M_AttributeSetInstance;
 import org.adempiere.core.domains.models.I_M_Locator;
 import org.adempiere.core.domains.models.I_S_ResourceAssignment;
 import org.adempiere.core.domains.models.X_AD_Reference;
+import org.compiere.model.MCountry;
+import org.compiere.model.MLookupFactory;
+import org.compiere.model.MLookupInfo;
 import org.compiere.model.MRefTable;
 import org.compiere.model.MValRule;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
+import org.compiere.util.Language;
 import org.compiere.util.Util;
 
 /**
@@ -48,6 +55,7 @@ public class ReferenceUtil {
 
 	/**
 	 * Validate reference
+	 * TODO: Add support to Resource Assigment reference to get display column
 	 * @param displayTypeId
 	 * @return
 	 */
@@ -62,7 +70,41 @@ public class ReferenceUtil {
 				|| DisplayType.PAttribute == displayTypeId) {
 			return true;
 		}
+		// if(DisplayType.Image == displayTypeId) {
+		// 	return AttachmentUtil.getInstance()
+		// 		.isValidForClient(
+		// 			Env.getAD_Client_ID(Env.getCtx())
+		// 		);
+		// }
 		return false;
+	}
+
+	public static int overwriteDisplayType(int displayTypeId, int referenceValueId) {
+		int newDisplayType = displayTypeId;
+		if (DisplayType.Button == displayTypeId) {
+			//	Reference Value
+			if (referenceValueId > 0) {
+				X_AD_Reference reference = new X_AD_Reference(
+					Env.getCtx(),
+					referenceValueId,
+					null
+				);
+				if (reference != null && reference.getAD_Reference_ID() > 0) {
+					// overwrite display type to Table or List
+					if (X_AD_Reference.VALIDATIONTYPE_TableValidation.equals(reference.getValidationType())) {
+						newDisplayType = DisplayType.Table;
+					} else {
+						newDisplayType = DisplayType.List;
+					}
+				}
+			}
+		} else if (DisplayType.TableDir == displayTypeId) {
+			if (referenceValueId > 0) {
+				// overwrite display type to Table (as C_DocTypeTarget_ID > C_DocType_ID)
+				newDisplayType = DisplayType.Table;
+			}
+		}
+		return newDisplayType;
 	}
 
 	/**
@@ -113,25 +155,26 @@ public class ReferenceUtil {
 		}
 
 		if(displayTypeId > 0 && ReferenceUtil.isLookupReference(displayTypeId)) {
-//			X_AD_Reference reference = new X_AD_Reference(Env.getCtx(), displayTypeId, null);
-//			MLookupInfo lookupInformation = null;
 			String tableName = getTableNameFromReference(columnName, displayTypeId);
-//			//	Special references
-//			if(Util.isEmpty(tableName)) {
-//				lookupInformation = MLookupFactory.getLookupInfo(Env.getCtx(), 0, 0, referenceId, Language.getBaseLanguage(), columnName, referenceValueId, false, null, false);
-//				if(lookupInformation != null) {
-//					String validationRuleValue = null;
-//					if(validationRuleId > 0) {
-//						MValRule validationRule = MValRule.get(Env.getCtx(), validationRuleId);
-//						validationRuleValue = validationRule.getCode();
-//					}
-//					tableName = lookupInformation.TableName;
-//					embeddedContextColumn = Optional.ofNullable(lookupInformation.Query).orElse("") 
-//							+ Optional.ofNullable(lookupInformation.QueryDirect).orElse("") 
-//							+ Optional.ofNullable(lookupInformation.ValidationCode).orElse("")
-//							+ Optional.ofNullable(validationRuleValue).orElse("");
-//				}
-//			}
+			// X_AD_Reference reference = new X_AD_Reference(Env.getCtx(), displayTypeId, null);
+			// MLookupInfo lookupInformation = null;
+			// //	Special references
+			// if(Util.isEmpty(tableName)) {
+			// 	lookupInformation = MLookupFactory.getLookupInfo(Env.getCtx(), 0, 0, referenceId, Language.getBaseLanguage(), columnName, referenceValueId, false, null, false);
+			// 	if(lookupInformation != null) {
+			// 		String validationRuleValue = null;
+			// 		if(validationRuleId > 0) {
+			// 			MValRule validationRule = MValRule.get(Env.getCtx(), validationRuleId);
+			// 			validationRuleValue = validationRule.getCode();
+			// 		}
+			// 		tableName = lookupInformation.TableName;
+			// 		embeddedContextColumn = Optional.ofNullable(lookupInformation.Query).orElse("") 
+			// 			+ Optional.ofNullable(lookupInformation.QueryDirect).orElse("") 
+			// 			+ Optional.ofNullable(lookupInformation.ValidationCode).orElse("")
+			// 			+ Optional.ofNullable(validationRuleValue).orElse("")
+			// 		;
+			// 	}
+			// }
 			String whereClauseReference = null;
 			String validationRuleValue = null;
 			if(validationRuleId > 0) {
@@ -184,6 +227,431 @@ public class ReferenceUtil {
 			tableName = I_C_ElementValue.Table_Name;
 		}
 		return tableName;
+	}
+
+
+
+	public static String getDisplayColumnSQLImage(String tableName, String columnName) {
+		StringBuffer query = new StringBuffer()
+			.append("SELECT ")
+			.append("NVL(UUID, '')")
+			.append(" || '-' || ")
+			.append("NVL(FileName, '') ")
+			.append("FROM AD_AttachmentReference ")
+			.append("WHERE AD_Image_ID = ")
+			.append(tableName + "." + columnName)
+			// .append(" LIMIT 1")
+			.append(" AND ROWNUM = 1 ")
+		;
+		return query.toString();
+	}
+
+	public static String getQueryColumnSQLImage() {
+		StringBuffer query = new StringBuffer()
+			.append("SELECT ")
+			.append("AD_AttachmentReference.AD_AttachmentReference_ID, NULL, ")
+			.append("NVL(AD_AttachmentReference.UUID, '')")
+			.append(" || '-' || ")
+			.append("NVL(AD_AttachmentReference.FileName, ''), ")
+			.append("NVL(AD_AttachmentReference.UUID, '') AS UUID ")
+			.append("FROM AD_AttachmentReference ")
+			.append("INNER JOIN AD_Image AD_Image ")
+			.append("ON AD_Image.AD_Image_ID = AD_AttachmentReference.AD_Image_ID ")
+		;
+		return query.toString();
+	}
+
+	public static String getDirectQueryColumnSQLImage() {
+		String query = getQueryColumnSQLImage();
+		StringBuffer directQuery = new StringBuffer()
+			.append(query)
+			.append("WHERE AD_AttachmentReference.AD_Image_ID = ? ")
+			.append("AND ROWNUM = 1 ")
+		;
+		return directQuery.toString();
+	}
+
+
+
+	public static String getColumnsOrderLocation(String displaySequence, boolean isAddressReverse) {
+		StringBuffer cityPostalRegion = new StringBuffer();
+
+		String inStr = displaySequence.replace(",", "|| ', ' ");
+		String token;
+		int index = inStr.indexOf('@');
+		while (index != -1) {
+			cityPostalRegion.append(inStr.substring(0, index));          // up to @
+			inStr = inStr.substring(index + 1, inStr.length());   // from first @
+
+			int endIndex = inStr.indexOf('@');                     // next @
+			if (endIndex < 0) {
+				token = "";                                 // no second tag
+				endIndex = index + 1;
+			} else {
+				token = inStr.substring(0, endIndex);
+			}
+			//  Tokens
+			if (token.equals("C")) {
+				cityPostalRegion.append("|| NVL(C_Location.City, ")
+					.append("(SELECT NVL(C_City.Name, '') FROM C_City WHERE ")
+					.append("C_City.C_City_ID = C_Location.C_City_ID")
+					.append("), '') ");
+			} else if (token.equals("R")) {
+				// String regionName = "";
+				//  local region name
+				// if (!Util.isEmpty(country.getRegionName(), true)) {
+				//     regionName = " || ' " + country.getRegionName() + "'";
+				// }
+				cityPostalRegion.append("|| NVL((SELECT NVL(C_Region.Name, '') FROM C_Region ")
+					.append("WHERE C_Region.C_Region_ID = C_Location.C_Region_ID")
+					.append("), '') ");
+			} else if (token.equals("P")) {
+				cityPostalRegion.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Postal + ", '') ");
+			} else if (token.equals("A")) {
+				cityPostalRegion.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Postal_Add + ", '') ");
+			} else {
+				cityPostalRegion.append("@").append(token).append("@");
+			}
+
+			inStr = inStr.substring(endIndex + 1, inStr.length());   // from second @
+			index = inStr.indexOf('@');
+		}
+		cityPostalRegion.append(inStr); // add the rest of the string 
+
+		StringBuffer query = new StringBuffer();
+		if (isAddressReverse) {
+			query.append("'' ")
+				.append(cityPostalRegion)
+				.append("|| ', ' ")
+				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address4 + " || ', ' , '') ")
+				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address3 + " || ', ' , '') ")
+				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address2 + " || ', ' , '') ")
+				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address1 + ", '')")
+			;
+		} else {
+			query.append("'' ")
+				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address1 + " || ', ' , '') ")
+				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address2 + " || ', ' , '')  ")
+				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address3 + " || ', ' , '')  ")
+				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address4 + " || ', ' , '') ")
+				.append(cityPostalRegion)
+			;
+		}
+
+		return query.toString();
+	}
+
+	public static String getDisplayColumnSQLLocation(String tableName, String columnName) {
+		MCountry country = MCountry.getDefault(Env.getCtx());
+		boolean isAddressReverse = country.isAddressLinesLocalReverse() || country.isAddressLinesReverse();
+		String displaySequence = country.getDisplaySequenceLocal();
+		String columnsOrder = getColumnsOrderLocation(displaySequence, isAddressReverse);
+
+		StringBuffer query = new StringBuffer()
+			.append("SELECT ")
+			.append("NVL(" + columnsOrder + ", '') ")
+			.append("FROM C_Location ")
+			.append("WHERE C_Location.C_Location_ID = ")
+			.append(tableName + "." + columnName)
+		;
+
+		return query.toString();
+	}
+
+	public static String getQueryLocation() {
+		MCountry country = MCountry.getDefault(Env.getCtx());
+		boolean isAddressReverse = country.isAddressLinesLocalReverse() || country.isAddressLinesReverse();
+		String displaySequence = country.getDisplaySequenceLocal();
+		String columnsOrder = getColumnsOrderLocation(displaySequence, isAddressReverse);
+
+		StringBuffer query = new StringBuffer()
+			.append("SELECT ")
+			.append("C_Location.C_Location_ID, NULL, ")
+			.append("NVL(" + columnsOrder + ", '-1'), ")
+			.append("C_Location.IsActive ")
+			.append("FROM C_Location ")
+		;
+
+		return query.toString();
+	}
+
+	public static String getDirectQueryLocation() {
+		String query = getQueryLocation();
+		StringBuffer directQuery = new StringBuffer()
+			.append(query)
+			.append("WHERE C_Location.C_Location_ID = ? ")
+		;
+
+		return directQuery.toString();
+	}
+
+
+
+	/**
+	 * Get Reference information, can return null if reference is invalid or not exists
+	 * @param referenceId
+	 * @param referenceValueId
+	 * @param columnName
+	 * @param validationRuleId
+	 * @return
+	 */
+	public static MLookupInfo getReferenceLookupInfo(int referenceId, int referenceValueId, String columnName, int validationRuleId) {
+		return getReferenceLookupInfo(
+			referenceId,
+			referenceValueId,
+			columnName,
+			validationRuleId,
+			null
+		);
+	}
+	/**
+	 * Get Reference information, can return null if reference is invalid or not exists
+	 * @param referenceId
+	 * @param referenceValueId
+	 * @param columnName
+	 * @param validationRuleId
+	 * @param customRestriction
+	 * @return
+	 */
+	public static MLookupInfo getReferenceLookupInfo(int referenceId, int referenceValueId, String columnName, int validationRuleId, String customRestriction) {
+		if(!isLookupReference(referenceId)) {
+			return null;
+		}
+		MLookupInfo lookupInformation = null;
+		if (DisplayType.Account == referenceId) {
+			columnName = I_C_ValidCombination.COLUMNNAME_C_ValidCombination_ID;
+		}
+
+		if (DisplayType.Location == referenceId) {
+			columnName = I_C_Location.COLUMNNAME_C_Location_ID;
+			lookupInformation = getLookupInfoFromColumnName(columnName);
+			lookupInformation.Query = getQueryLocation();
+			lookupInformation.QueryDirect = getDirectQueryLocation();
+		} else if (DisplayType.PAttribute == referenceId) {
+			columnName = I_M_AttributeSetInstance.COLUMNNAME_M_AttributeSetInstance_ID;
+			lookupInformation = getLookupInfoFromColumnName(columnName);
+			lookupInformation.DisplayType = referenceId;
+			lookupInformation.Query = "SELECT M_AttributeSetInstance.M_AttributeSetInstance_ID, "
+				+ "NULL, M_AttributeSetInstance.Description, M_AttributeSetInstance.IsActive "
+				+ "FROM M_AttributeSetInstance ";
+			lookupInformation.QueryDirect = lookupInformation.Query
+				+ "WHERE M_AttributeSetInstance.M_AttributeSetInstance_ID = ? ";
+		} else if (DisplayType.Locator == referenceId) {
+			columnName = I_M_Locator.COLUMNNAME_M_Locator_ID;
+			lookupInformation = getLookupInfoFromColumnName(columnName);
+			lookupInformation.DisplayType = referenceId;
+			lookupInformation.Query = "SELECTM_Locator.M_Locator_ID, "
+				+ "NULL, M_Locator.Value, M_Locatore.IsActive "
+				+ "FROM M_Locator ";
+			lookupInformation.QueryDirect = lookupInformation.Query
+				+ "WHERE M_Locator.M_Locator_ID = ? ";
+		} else if(DisplayType.Image == referenceId) {
+			columnName = I_AD_Image.COLUMNNAME_AD_Image_ID;
+			lookupInformation = getLookupInfoFromColumnName(columnName);
+			lookupInformation.DisplayType = referenceId;
+			lookupInformation.Query = getQueryColumnSQLImage();
+			lookupInformation.QueryDirect = getDirectQueryColumnSQLImage();
+		} else if(DisplayType.TableDir == referenceId
+				|| referenceValueId <= 0) {
+			// TODO: Add support on MLookupInfo to reuse on Zk/Swing
+			if (AccountingUtils.USER_ELEMENT_COLUMNS.contains(columnName)) {
+				String newColumnName = AccountingUtils.overwriteColumnName(columnName);
+				if (!Util.isEmpty(newColumnName, true)) {
+					columnName = newColumnName;
+				}
+			}
+			//	Add Display
+			lookupInformation = getLookupInfoFromColumnName(columnName);
+		} else {
+			//	Get info
+			lookupInformation = getLookupInfoFromReference(referenceValueId);
+		}
+
+		// without lookup info
+		if (lookupInformation == null) {
+			return null;
+		}
+
+		//	For validation
+		String queryForLookup = lookupInformation.Query;
+		//	Add support to UUID
+		queryForLookup = getQueryWithUuid(lookupInformation.TableName, queryForLookup);
+		String directQuery = getQueryWithUuid(lookupInformation.TableName, lookupInformation.QueryDirect);
+
+		// set new query
+		lookupInformation.Query = queryForLookup;
+		lookupInformation.QueryDirect = directQuery;
+		lookupInformation.DisplayType = referenceId;
+		lookupInformation.AD_Reference_Value_ID = referenceValueId;
+
+		MValRule validationRule = null;
+		//	For validation rule
+		if (validationRuleId > 0) {
+			validationRule = MValRule.get(Env.getCtx(), validationRuleId);
+			if (validationRule != null) {
+				if (!Util.isEmpty(validationRule.getCode(), true)) {
+					String dynamicValidation = validationRule.getCode();
+					if (!validationRule.getCode().startsWith("(")) {
+						dynamicValidation = "(" + validationRule.getCode() + ")";
+					}
+					// // table validation
+					// if (!Util.isEmpty(lookupInformation.ValidationCode, true)) {
+					// 	dynamicValidation += " AND (" + lookupInformation.ValidationCode + ")";
+					// }
+					// overwrite ValidationCode with table validation on reference and dynamic validation
+					lookupInformation.ValidationCode = dynamicValidation;
+				}
+			}
+		}
+		if (!Util.isEmpty(customRestriction, true)) {
+			if (!Util.isEmpty(lookupInformation.ValidationCode)
+				&& !(customRestriction.trim().startsWith("AND ") || customRestriction.trim().startsWith("OR "))
+			 ) {
+				lookupInformation.ValidationCode += " AND ";
+			}
+			lookupInformation.ValidationCode += " (" + customRestriction + ")";
+		}
+
+		// return only code without validation rule
+		if (Util.isEmpty(lookupInformation.ValidationCode, true)) {
+			return lookupInformation;
+		}
+
+		// remove order by
+		String queryWithoutOrder = queryForLookup;
+		int positionOrder = queryForLookup.lastIndexOf(" ORDER BY ");
+		String orderByQuery = "";
+		if (positionOrder != -1) {
+			orderByQuery = queryForLookup.substring(positionOrder);
+			queryWithoutOrder = queryForLookup.substring(0, positionOrder);
+		}
+
+		// add where clause with validation code
+		int positionFrom = queryForLookup.lastIndexOf(" FROM ");
+		boolean hasWhereClause = queryForLookup.indexOf(" WHERE ", positionFrom) != -1;
+		if (hasWhereClause) {
+			queryWithoutOrder += " AND ";
+		} else {
+			queryWithoutOrder += " WHERE ";
+		}
+		queryWithoutOrder += " " + lookupInformation.ValidationCode;
+
+		// Add new query with where clause and order By
+		queryForLookup = queryWithoutOrder + orderByQuery;
+
+		// set new query
+		lookupInformation.Query = queryForLookup;
+
+		return lookupInformation;
+	}
+
+	/**
+	 * Get Lookup info from reference
+	 * @param referenceId
+	 * @return
+	 */
+	private static MLookupInfo getLookupInfoFromReference(int referenceId) {
+		MLookupInfo lookupInformation = null;
+		X_AD_Reference reference = new X_AD_Reference(Env.getCtx(), referenceId, null);
+		if (reference == null || reference.getAD_Reference_ID() <= 0) {
+			return null;
+		}
+		if(reference.getValidationType().equals(X_AD_Reference.VALIDATIONTYPE_TableValidation)) {
+			lookupInformation = MLookupFactory.getLookupInfo(
+				Env.getCtx(),
+				0,
+				0,
+				DisplayType.Search,
+				Language.getLanguage(Env.getAD_Language(Env.getCtx())),
+				null,
+				reference.getAD_Reference_ID(),
+				false,
+				null,
+				false
+			);
+		} else if(reference.getValidationType().equals(X_AD_Reference.VALIDATIONTYPE_ListValidation)) {
+			lookupInformation = MLookupFactory.getLookup_List(
+				Language.getLanguage(Env.getAD_Language(Env.getCtx())),
+				reference.getAD_Reference_ID()
+			);
+		}
+		return lookupInformation;
+	}
+
+
+
+	/**
+	 * Get Query with UUID
+	 * @param tableName
+	 * @param query
+	 * @return
+	 */
+	public static String getQueryWithUuid(String tableName, String query) {
+		Matcher matcherFrom = Pattern.compile(
+			"\\s+(FROM)\\s+(" + tableName + ")",
+			Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+		).matcher(query);
+
+		List<MatchResult> fromWhereParts = matcherFrom.results()
+			.collect(Collectors.toList())
+		;
+
+		String queryWithUuid = query;
+		if (fromWhereParts != null && fromWhereParts.size() > 0) {
+			MatchResult lastFrom = fromWhereParts.get(fromWhereParts.size() - 1);
+			queryWithUuid = query.substring(0, lastFrom.start());
+			queryWithUuid += ", " + tableName + ".UUID";
+			queryWithUuid += query.substring(lastFrom.start());
+		}
+
+		return queryWithUuid;
+	}
+
+	/**
+	 * Get Query with UUID
+	 * @param tableName
+	 * @param query
+	 * @return
+	 */
+	public static String getQueryWithActiveRestriction(String tableName, String query) {
+		Matcher matcherFrom = Pattern.compile(
+			"\\s+(FROM)\\s+(" + tableName + ")",
+			Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+		).matcher(query);
+
+		List<MatchResult> fromWhereParts = matcherFrom.results()
+			.collect(Collectors.toList())
+		;
+
+		String queryWithUuid = query;
+		if (fromWhereParts != null && fromWhereParts.size() > 0) {
+			MatchResult lastFrom = fromWhereParts.get(fromWhereParts.size() - 1);
+			queryWithUuid = query.substring(0, lastFrom.start());
+			queryWithUuid += ", " + tableName + ".UUID";
+			queryWithUuid += query.substring(lastFrom.start());
+		}
+
+		return queryWithUuid;
+	}
+
+	/**
+	 * Get Lookup info from column name
+	 * @param columnName
+	 * @return
+	 */
+	private static MLookupInfo getLookupInfoFromColumnName(String columnName) {
+		return MLookupFactory.getLookupInfo(
+			Env.getCtx(),
+			0,
+			0,
+			DisplayType.TableDir,
+			Language.getLanguage(Env.getAD_Language(Env.getCtx())),
+			columnName,
+			0,
+			false,
+			null,
+			false
+		);
 	}
 
 }

--- a/src/main/java/org/spin/eca56/util/support/documents/ReferenceValues.java
+++ b/src/main/java/org/spin/eca56/util/support/documents/ReferenceValues.java
@@ -17,35 +17,97 @@
  *****************************************************************************/
 package org.spin.eca56.util.support.documents;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.compiere.model.MLookupInfo;
+import org.compiere.model.MTable;
+import org.compiere.util.Env;
+
 /**
  * 	The Stub class for reference
  * 	@author Yamel Senih, ysenih@erpya.com, ERPCyA http://www.erpya.com
  */
 public class ReferenceValues {
+
 	private String tableName;
+	private String accessLevel;
+	private int displayTypeId;
+	private int referenceValueId;
 	private String embeddedContextColumn;
-	private int referenceId;
-	
-	private ReferenceValues(int referenceId, String tableName, String embeddedContextColumn) {
-		this.referenceId = referenceId;
+	private List<String> contextColumns;
+
+
+
+	private ReferenceValues(String tableName, String accessLevel, int displayTypeId, int referenceValueId, String embeddedContextColumn, List<String> contextColumns) {
+		this.displayTypeId = displayTypeId;
 		this.tableName = tableName;
+		this.accessLevel = accessLevel;
+		this.referenceValueId = referenceValueId;
 		this.embeddedContextColumn = embeddedContextColumn;
+		this.contextColumns = contextColumns;
 	}
-	
-	public static ReferenceValues newInstance(int referenceId, String tableName, String embeddedContextColumn) {
-		return new ReferenceValues(referenceId, tableName, embeddedContextColumn);
+
+
+
+	public static ReferenceValues newInstance(int displayTypeId, String tableName, String embeddedContextColumn) {
+		MTable table = MTable.get(Env.getCtx(), tableName);
+		List<String> contextColumnsList = ReferenceUtil.getContextColumnNames(
+			Optional.ofNullable(embeddedContextColumn).orElse("")
+		);
+		return new ReferenceValues(
+			tableName,
+			table.getAccessLevel(),
+			displayTypeId,
+			0,
+			embeddedContextColumn,
+			contextColumnsList
+		);
 	}
-	
+
+	public static ReferenceValues newInstance(MLookupInfo lookupInfo) {
+		MTable table = MTable.get(Env.getCtx(), lookupInfo.TableName);
+		String embeddedContextColumn = Optional.ofNullable(lookupInfo.QueryDirect).orElse("")
+			+ Optional.ofNullable(lookupInfo.Query).orElse("")
+			+ Optional.ofNullable(lookupInfo.ValidationCode).orElse("")
+		;
+		List<String> contextColumnsList = ReferenceUtil.getContextColumnNames(
+			Optional.ofNullable(embeddedContextColumn).orElse("")
+		);
+		return new ReferenceValues(
+			table.getTableName(),
+			table.getAccessLevel(),
+			lookupInfo.DisplayType,
+			lookupInfo.AD_Reference_Value_ID,
+			embeddedContextColumn,
+			contextColumnsList
+		);
+	}
+
+
+
 	public String getTableName() {
 		return tableName;
 	}
-	
+
+	public String getAccessLevel() {
+		return accessLevel;
+	}
+
+	public int getDisplayTypeId() {
+		return displayTypeId;
+	}
+
+	public int getReferenceValueId() {
+		return referenceValueId;
+	}
+
 	public String getEmbeddedContextColumn() {
 		return embeddedContextColumn;
 	}
-	
-	public int getReferenceId() {
-		return referenceId;
+
+	public List<String> getContextColumns() {
+		return contextColumns;
 	}
 
 }

--- a/src/main/java/org/spin/eca56/util/support/documents/Window.java
+++ b/src/main/java/org/spin/eca56/util/support/documents/Window.java
@@ -26,21 +26,25 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.adempiere.core.domains.models.I_AD_ChangeLog;
 import org.adempiere.core.domains.models.I_AD_Element;
 import org.adempiere.core.domains.models.I_AD_Field;
 import org.adempiere.core.domains.models.I_AD_Process;
 import org.adempiere.core.domains.models.I_AD_Tab;
+import org.adempiere.core.domains.models.I_AD_Table;
 import org.adempiere.core.domains.models.I_AD_Window;
 import org.adempiere.model.MBrowse;
 import org.compiere.model.MColumn;
 import org.compiere.model.MField;
 import org.compiere.model.MForm;
+import org.compiere.model.MLookupInfo;
 import org.compiere.model.MProcess;
 import org.compiere.model.MTab;
 import org.compiere.model.MTable;
 import org.compiere.model.MWindow;
 import org.compiere.model.PO;
 import org.compiere.model.Query;
+import org.compiere.util.DisplayType;
 import org.compiere.wf.MWorkflow;
 import org.spin.eca56.util.support.DictionaryDocument;
 
@@ -428,7 +432,7 @@ public class Window extends DictionaryDocument {
 			displayTypeId = column.getAD_Reference_ID();
 		}
 		detail.put("display_type", displayTypeId);
-		
+
 		//	Value Properties
 		detail.put("default_value", Optional.ofNullable(field.getDefaultValue()).orElse(column.getDefaultValue()));
 		detail.put("field_length", column.getFieldLength());
@@ -464,29 +468,45 @@ public class Window extends DictionaryDocument {
 		if(referenceValueId <= 0) {
 			referenceValueId = column.getAD_Reference_Value_ID();
 		}
-		int validationRuleId = field.getAD_Val_Rule_ID();
-		if(validationRuleId <= 0) {
-			validationRuleId = column.getAD_Val_Rule_ID();
+
+		// overwrite display type `Button` to `List`, example `PaymentRule` or `Posted`
+		displayTypeId = ReferenceUtil.overwriteDisplayType(
+			displayTypeId,
+			referenceValueId
+		);
+		if (ReferenceUtil.isLookupReference(displayTypeId)) {
+			//	Validation Code
+			int validationRuleId = field.getAD_Val_Rule_ID();
+			if(validationRuleId <= 0) {
+				validationRuleId = column.getAD_Val_Rule_ID();
+			}
+
+			MLookupInfo info = ReferenceUtil.getReferenceLookupInfo(
+				displayTypeId, referenceValueId, column.getColumnName(), validationRuleId
+			);
+			if (info != null) {
+				ReferenceValues referenceValues = ReferenceValues.newInstance(info);
+				Map<String, Object> referenceDetail = new HashMap<>();
+				referenceDetail.put("table_name", referenceValues.getTableName());
+				referenceDetail.put("access_level", referenceValues.getAccessLevel());
+				referenceDetail.put("reference_id", referenceValues.getDisplayTypeId());
+				referenceDetail.put("reference_value_id", referenceValues.getReferenceValueId());
+				referenceDetail.put("context_column_names", referenceValues.getContextColumns());
+				detail.put("reference", referenceDetail);
+			} else {
+				// detail.put("display_type", DisplayType.String);
+			}
+		} else if (DisplayType.Button == displayTypeId) {
+			if (column.getColumnName().equals(I_AD_ChangeLog.COLUMNNAME_Record_ID)) {
+				// To load default value
+				// builder.addContextColumnNames(I_AD_Table.COLUMNNAME_AD_Table_ID);
+				detail.put("context_column_names", Arrays.asList(I_AD_Table.COLUMNNAME_AD_Table_ID));
+			}
 		}
 
-		ReferenceValues referenceValues = ReferenceUtil.getReferenceDefinition(
-			column.getColumnName(),
-			displayTypeId,
-			referenceValueId,
-			validationRuleId
-		);
-		if(referenceValues != null) {
-			Map<String, Object> referenceDetail = new HashMap<>();
-			referenceDetail.put("table_name", referenceValues.getTableName());
-			referenceDetail.put("reference_id", referenceValues.getReferenceId());
-			referenceDetail.put("reference_value_id", referenceValueId);
-			referenceDetail.put("context_column_names", ReferenceUtil.getContextColumnNames(
-					referenceValues.getEmbeddedContextColumn()
-				)
-			);
-			detail.put("reference", referenceDetail);
-		}
-		detail.put("context_column_names", ReferenceUtil.getContextColumnNames(
+		detail.put(
+			"context_column_names",
+			ReferenceUtil.getContextColumnNames(
 				Optional.ofNullable(field.getDefaultValue()).orElse(column.getDefaultValue())
 			)
 		);


### PR DESCRIPTION
When you have a table reference, and/or a dynamic validation that uses context, it does not correctly generate the context columns.